### PR TITLE
feat: implement bookmark deletion functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An integration that allows LLMs to interact with Raindrop.io bookmarks using the
 
 - Create bookmarks
 - Search bookmarks
+- Delete bookmarks
 - Filter by tags
 
 ## Requirements
@@ -92,6 +93,12 @@ Searches through bookmarks.
 **Parameters:**
 - `query`: Search query (required)
 - `tags`: Array of tags to filter by (optional)
+
+### delete-bookmark
+Deletes a bookmark by ID.
+
+**Parameters:**
+- `id`: Bookmark ID to delete (required)
 
 ## Development
 

--- a/src/__tests__/raindrop.test.ts
+++ b/src/__tests__/raindrop.test.ts
@@ -150,4 +150,39 @@ describe("RaindropAPI", () => {
       });
     });
   });
+
+  describe("deleteBookmark", () => {
+    it("deletes a bookmark", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ result: true }),
+      } as Response);
+
+      const result = await api.deleteBookmark(123);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.raindrop.io/rest/v1/raindrop/123",
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer test-token`,
+          },
+        },
+      );
+      expect(result).toEqual({ result: true });
+    });
+
+    it("handles API errors", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: "Not Found",
+        json: () => Promise.resolve({ error: "Not Found" }),
+      } as Response);
+
+      await expect(api.deleteBookmark(999)).rejects.toThrow(
+        "Raindrop API error: Not Found",
+      );
+    });
+  });
 });

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, jest } from "@jest/globals";
 import { CallToolRequest } from "@modelcontextprotocol/sdk/types.js";
 import { RaindropAPI } from "../lib/raindrop-api.js";
-import { CreateBookmarkSchema, SearchBookmarksSchema } from "../types/index.js";
+import { CreateBookmarkSchema, SearchBookmarksSchema, DeleteBookmarkSchema } from "../types/index.js";
 
 // モックのfetch関数
 const mockFetch = jest.fn().mockImplementation(() =>
@@ -325,6 +325,136 @@ Created: ${new Date(item.created).toLocaleString()}
       });
 
       expect(result.content[0].text).toBe("No collections found.");
+    });
+  });
+
+  describe("delete-bookmark", () => {
+    const handler = async (request: CallToolRequest) => {
+      const { name, arguments: args } = request.params;
+      if (name !== "delete-bookmark") throw new Error("Invalid tool");
+
+      const { id } = DeleteBookmarkSchema.parse(args);
+
+      try {
+        const result = await api.deleteBookmark(id);
+
+        if (result.result) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Bookmark with ID ${id} has been successfully deleted.`,
+              },
+            ],
+          };
+        } else {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Failed to delete bookmark with ID ${id}. The bookmark may not exist or you don't have permission to delete it.`,
+              },
+            ],
+          };
+        }
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("404")) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Bookmark with ID ${id} not found. It may have already been deleted or the ID is incorrect.`,
+              },
+            ],
+          };
+        }
+        throw error;
+      }
+    };
+
+    it("should delete a bookmark successfully", async () => {
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ result: true }),
+        }),
+      );
+
+      const result = await handler({
+        method: "tools/call",
+        params: {
+          name: "delete-bookmark",
+          arguments: {
+            id: 123,
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Bookmark with ID 123 has been successfully deleted.",
+          },
+        ],
+      });
+    });
+
+    it("should handle deletion failure", async () => {
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ result: false }),
+        }),
+      );
+
+      const result = await handler({
+        method: "tools/call",
+        params: {
+          name: "delete-bookmark",
+          arguments: {
+            id: 123,
+          },
+        },
+      });
+
+      expect(result.content[0].text).toContain("Failed to delete bookmark with ID 123");
+    });
+
+    it("should handle 404 errors", async () => {
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: false,
+          statusText: "Not Found",
+          json: () => Promise.resolve({ error: "Not Found" }),
+        }),
+      );
+
+      const result = await handler({
+        method: "tools/call",
+        params: {
+          name: "delete-bookmark",
+          arguments: {
+            id: 999,
+          },
+        },
+      });
+
+      expect(result.content[0].text).toContain("Bookmark with ID 999 not found");
+    });
+
+    it("should handle validation errors", async () => {
+      await expect(
+        handler({
+          method: "tools/call",
+          params: {
+            name: "delete-bookmark",
+            arguments: {
+              id: "invalid-id",
+            },
+          },
+        }),
+      ).rejects.toThrow();
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import dotenv from "dotenv";
 import { z } from "zod";
 import { RaindropAPI } from "./lib/raindrop-api.js";
 import { tools } from "./lib/tools.js";
-import { CreateBookmarkSchema, SearchBookmarksSchema } from "./types/index.js";
+import { CreateBookmarkSchema, SearchBookmarksSchema, DeleteBookmarkSchema } from "./types/index.js";
 
 dotenv.config();
 
@@ -133,6 +133,46 @@ Created: ${new Date(item.created).toLocaleString()}
             },
           ],
         };
+      }
+
+      if (name === "delete-bookmark") {
+        const { id } = DeleteBookmarkSchema.parse(args);
+
+        try {
+          const result = await api.deleteBookmark(id);
+
+          if (result.result) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Bookmark with ID ${id} has been successfully deleted.`,
+                },
+              ],
+            };
+          } else {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Failed to delete bookmark with ID ${id}. The bookmark may not exist or you don't have permission to delete it.`,
+                },
+              ],
+            };
+          }
+        } catch (error) {
+          if (error instanceof Error && error.message.includes("404")) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Bookmark with ID ${id} not found. It may have already been deleted or the ID is incorrect.`,
+                },
+              ],
+            };
+          }
+          throw error;
+        }
       }
 
       throw new Error(`Unknown tool: ${name}`);

--- a/src/lib/raindrop-api.ts
+++ b/src/lib/raindrop-api.ts
@@ -55,4 +55,8 @@ export class RaindropAPI {
   async listCollections(): Promise<CollectionsResponse> {
     return this.makeRequest<CollectionsResponse>("/collections");
   }
+
+  async deleteBookmark(id: number): Promise<{ result: boolean }> {
+    return this.makeRequest<{ result: boolean }>(`/raindrop/${id}`, "DELETE");
+  }
 }

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -87,4 +87,18 @@ export const tools: Tool[] = [
       properties: {},
     },
   },
+  {
+    name: "delete-bookmark",
+    description: "Delete a bookmark from Raindrop.io",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "number",
+          description: "ID of the bookmark to delete",
+        },
+      },
+      required: ["id"],
+    },
+  },
 ];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,9 +29,14 @@ export const SearchBookmarksSchema = z.object({
   word: z.boolean().optional(),
 });
 
+export const DeleteBookmarkSchema = z.object({
+  id: z.number().int().positive(),
+});
+
 // Zodスキーマから型を生成
 export type CreateBookmarkParams = z.infer<typeof CreateBookmarkSchema>;
 export type SearchBookmarksParams = z.infer<typeof SearchBookmarksSchema>;
+export type DeleteBookmarkParams = z.infer<typeof DeleteBookmarkSchema>;
 
 // APIレスポンスの型
 export interface RaindropItem {


### PR DESCRIPTION
- Add delete-bookmark tool definition with validation schema
- Create API client method for DELETE /raindrop/{id} endpoint  
- Add comprehensive error handling for 404 and permission errors
- Update documentation with new tool description
- Add unit tests for API method and tool handler

Fixes #4